### PR TITLE
Support n-ary functions in expressions

### DIFF
--- a/specgen/spec/sec-structure.s
+++ b/specgen/spec/sec-structure.s
@@ -206,7 +206,7 @@ associativity directions.
 
 @syntax[:name "Term"]{
          - @ms{Expression}
-    @alt @ms{Identifier} ( @ms{Expression} )
+    @alt @ms{Identifier} ( @ms{Expression List} )
     @alt ( @ms{Expression} )
     @alt @ms{Complex}
     @alt @ms{Parameter}


### PR DESCRIPTION
The new EXTERN declaration syntax allows for arbitrary functions on classical memory to be used (with some restrictions) in Quil's expression syntax. I do not believe that anyone involved in the standardization process assumed that expressions should restrict themselves to unary functions.

E.g. 

```
RX(func1(1,2,x)) 0
```

Should be legal syntax.

@erichulburd let me know if you think so too.