### PR TITLE
Extend numeric literals to support hexadecimal, octal, binary, and underscores

### DIFF
--- a/grammars/Quil.g4
+++ b/grammars/Quil.g4
@@ -235,8 +235,15 @@ IDENTIFIER          : ( ( [A-Za-z_] ) | ( [A-Za-z_] [A-Za-z0-9\-_]* [A-Za-z0-9_]
 
 // Numbers
 
-INT                 : [0-9]+ ;
-FLOAT               : [0-9]+ ( '.' [0-9]+ )? ( ( 'e'|'E' ) ( '+' | '-' )? [0-9]+ )? ;
+INT                 : DEC_INT | HEX_INT | OCT_INT | BIN_INT ;
+FLOAT               : (DEC_INT | DEC_FLOAT) ([Ee] ('+' | '-')? '_'* DEC_INT)? ;
+
+fragment DEC_INT    : [0-9] [0-9_]+ ;
+fragment HEX_INT    : '0' [Xx] '_'* [0-9A-Fa-f] [0-9A-Fa-f_]* ;
+fragment OCT_INT    : '0' [Oo] '_'* [0-7] [0-7_]* ;
+fragment BIN_INT    : '0' [Bb] '_'* [01] [01_]* ;
+
+fragment DEC_FLOAT  : DEC_INT '.' DEC_INT? | '.' DEC_INT
 
 // String
 

--- a/specgen/quil.lisp
+++ b/specgen/quil.lisp
@@ -529,10 +529,11 @@
 
 
 (defun write-quil-spec (&optional (document (make-quil-spec-document)))
-  (with-open-file (s (site/ "index.html")
-                     :direction ':output
-                     :if-exists ':supersede
-                     :if-does-not-exist ':create)
-    (html s document)
-    (format t "~&; Wrote ~A.~%" (site/ "spec.html"))
-    nil))
+  (let ((filename (site/ "index.html")))
+    (with-open-file (s filename
+                       :direction ':output
+                       :if-exists ':supersede
+                       :if-does-not-exist ':create)
+      (html s document)
+      (format t "~&; Wrote ~A.~%" filename)
+      nil)))

--- a/specgen/spec/sec-structure.s
+++ b/specgen/spec/sec-structure.s
@@ -62,35 +62,75 @@ a line. Indents in Quil programs can only happen following a newline.}
 @p{Note that since indents must follow a newline, we include the
 newline as a part of the syntax definition of an indent.}
 
-@p{Non-negative integers are written as usual. Leading zeros do not
-change the interpretation of these numeric literals.}
+@p{Non-negative integers can be written in decimal, hexadecimal,
+octal, or binary. Decimal integers are written as usual, hexadecimal
+integers start with '@c{0x}', octal integers start with '@c{0o}', and
+binary integers start with '@c{0b}' (all case-insensitive). These
+integers may contain interior or trailing underscores, which are
+ignored; in the case of non-decimal integers, the underscores must
+come after the identifying prefix.}
 
 @syntax[:name "Integer"]{
-    @rep[:min 1]{[0-9]}
+       @ms{Decimal Integer}
+  @alt @ms{Hexadecimal Integer}
+  @alt @ms{Octal Integer}
+  @alt @ms{Binary Integer}
 }
 
-@p{Real numbers are written in usual floating-point number syntax.}
+@syntax[:name "Decimal Integer"]{
+    [0-9]@rep{[0-9_]}
+}
+
+@syntax[:name "Hexadecimal Integer"]{
+    0[Xx]@rep{_}[0-9A-Fa-f]@rep{[0-9A-Fa-f_]}
+}
+
+@syntax[:name "Octal Integer"]{
+    0[Oo]@rep{_}[0-7]@rep{[0-7_]}
+}
+
+@syntax[:name "Binary Integer"]{
+    0[Bb]@rep{_}[01]@rep{[01_]}
+}
+
+@p{Non-integral real numbers are written in the usual decimal
+floating-point number syntax (including an optional base-10 exponent
+prefixed by case-insensitive '@c{e}'), or as the special literal
+'@c{pi}'.  As with integers, decimal floating-point numbers may
+contain internal or trailing underscores.}
 
 @syntax[:name "Real"]{
-  @rep[:min 0 :max 1]{@ms{Integer}}
-  @rep[:min 0 :max 1]{.}
-  @ms{Integer}
-  @rep[:min 0 :max 1]{
-    @group{
-      @group{e @alt E}
-      @rep[:min 0 :max 1]{@group{- @alt +}}
-      @ms{Integer}
-    }
-  }
+       @ms{Numeric Real}
+  @alt pi
 }
 
-@p{Complex numbers are an extension of this.}
+@syntax[:name "Numeric Real"]{
+       @group{
+              @ms{Decimal Integer}
+         @alt @ms{Real With Decimal Point}
+       }@rep[:max 1]{@group{
+         [Ee]@rep[:max 1]{@group{- @alt +}}@rep{_}@ms{Decimal Integer}
+       }}
+  @alt @ms{Hexadecimal Integer}
+  @alt @ms{Octal Integer}
+  @alt @ms{Binary Integer}
+}
+
+@syntax[:name "Real With Decimal Point"]{
+        @ms{Decimal Integer}.@rep[:min 0 :max 1]{@ms{Decimal Integer}}
+  @alt .@ms{Decimal Integer}
+}
+
+@p{An imaginary number literal is an optional numeric real number
+followed by the letter '@c{i}' (case-@emph{sensitive}). A complex
+number literal is either a real number literal or an imaginary number
+literal.  (Something that looks like a mixed real and imaginary
+complex number, such as '@c{1+2i}', is actually an arithmetic
+expression and not a single literal.)}
 
 @syntax[:name "Complex"]{
-       @ms{Integer}
-  @alt @ms{Real}
-  @alt @rep[:min 0 :max 1]{@ms{Real}} i
-  @alt pi
+       @ms{Real}
+  @alt @rep[:max 1]{@ms{Numeric Real}}i
 }
 
 @p{Strings are characters bounded by double-quotation mark characters


### PR DESCRIPTION
This PR extends the lexical syntax of Quil to support numbers in formats other than `01234.5678e9`:

- Binary integers written `0b101010`
- Octal integers written `0o777`
- Hexadecimal integers written `0xABCDEF`
- Inserting underscores in the middle of integers for clarity, such as `1_000_000` or `0xFFFF_0000`.

It does not affect the dynamic or static semantics of the language in any way.