### PR TITLE
Update Quil-T specification of calibration matching and `DEFCAL MEASURE`

### DIFF
--- a/specgen/spec/sec-other.s
+++ b/specgen/spec/sec-other.s
@@ -96,7 +96,7 @@ of processing a @c{CALL} instruction is to increment the program counter.}
 
 @p{Note, for every @c{CALL} instruction, there must be a corresponding @c{EXTERN}
 declaration of the same identifier (case-sensitive). There is no restriction
-on the order of a @{CALL} instruction relative to its corresponding @c{EXTERN}
+on the order of a @c{CALL} instruction relative to its corresponding @c{EXTERN}
 declaration.}
 
 @p{When a function type signature specifies a return type, then calls

--- a/specgen/spec/sec-quilt.s
+++ b/specgen/spec/sec-quilt.s
@@ -327,10 +327,10 @@ DEFCAL RZ(%theta) qubit:
     SHIFT-PHASE qubit "xy" %theta
 
 # Measurement and classification
-DEFCAL MEASURE 0 %dest:
+DEFCAL MEASURE 0 dest:
     DECLARE iq REAL[2]
     CAPTURE 0 "out" flat(1e-6, 2+3i) iq
-    LT %dest iq[0] 0.5 # thresholding
+    LT dest iq[0] 0.5 # thresholding
 }
 }
 


### PR DESCRIPTION
The Quil-T spec was outdated with how we actually handle `DEFCAL`, and did not properly reflect that we prioritize exact matches.  There were also some small errors in the specification of `DEFCAL MEASURE`.